### PR TITLE
Don't convert VML urls.

### DIFF
--- a/lib/inline-images.js
+++ b/lib/inline-images.js
@@ -4,7 +4,7 @@ module.exports = function(less) {
 	
     function InlineImages() {
         this._visitor = new less.visitors.Visitor(this);
-    };
+    }
 
     InlineImages.prototype = {
         isReplacing: true,
@@ -22,6 +22,11 @@ module.exports = function(less) {
         visitUrl: function (URLNode, visitArgs) {
             if (!this._inRule) {
                 return URLNode;
+            }
+            if (URLNode.value.value.indexOf('#') === 0) {
+              // Might be part of a VML url-node value like:
+              // ``behavior:url(#default#VML);``
+              return URLNode;
             }
             return new less.tree.Call("data-uri", [new ParamStringReplacementNode(URLNode.value)], URLNode.index || 0, URLNode.currentFileInfo);
         }


### PR DESCRIPTION
Don't convert VML url-node values like the one: `behavior:url(#default#VML);` as seen in LeafletJS:
https://github.com/Leaflet/Leaflet/blob/master/dist/leaflet.css#L97

This is done by simply checking if the url value starts with a `#`.
