### PR TITLE
Update visitor for less 3.x API

### DIFF
--- a/lib/inline-images.js
+++ b/lib/inline-images.js
@@ -12,15 +12,15 @@ module.exports = function(less) {
         run: function (root) {
             return this._visitor.visit(root);
         },
-        visitRule: function (ruleNode, visitArgs) {
-            this._inRule = true;
-            return ruleNode;
+        visitDeclaration: function (declarationNode, visitArgs) {
+            this._inDeclaration = true;
+            return declarationNode;
         },
-        visitRuleOut: function (ruleNode, visitArgs) {
-            this._inRule = false;
+        visitDeclarationOut: function (declarationNode, visitArgs) {
+            this._inDeclaration = false;
         },
         visitUrl: function (URLNode, visitArgs) {
-            if (!this._inRule) {
+            if (!this._inDeclaration) {
                 return URLNode;
             }
             if (URLNode.value && URLNode.value.value && URLNode.value.value.indexOf('#') === 0) {
@@ -28,7 +28,7 @@ module.exports = function(less) {
               // ``behavior:url(#default#VML);``
               return URLNode;
             }
-            return new less.tree.Call("data-uri", [new ParamStringReplacementNode(URLNode.value)], URLNode.index || 0, URLNode.currentFileInfo);
+            return new less.tree.Call("data-uri", [new ParamStringReplacementNode(URLNode.value)], URLNode.index || 0, URLNode.fileInfo());
         }
     };
     return InlineImages;


### PR DESCRIPTION
We have a custom plugin based on this in one of our projects and it took a while to work out why it was no longer working with Less 3.x - there have been some changes to the Tree API that aren't (or don't seem to be) fully documented.

I haven't tested this change specifically with this plugin, since ours does something slightly different - in particular I don't know if the `less.tree.Call("data-uri"` call actually works as we just do a string replacement on the URL value itself.